### PR TITLE
feat(frontend-react-emotion): create util method to create context :sparkles:

### DIFF
--- a/packages/frontend-react-emotion/src/utils/context.ts
+++ b/packages/frontend-react-emotion/src/utils/context.ts
@@ -1,0 +1,58 @@
+import {
+  Context,
+  createContext as ReactCreateContext,
+  Provider,
+  useContext as ReactUseContext,
+} from "react";
+
+export interface CreateContextOptions {
+  /**
+   * ture の場合、context の値がエラーの場合にエラーをスローします。
+   */
+  strict?: boolean;
+  /**
+   * context の値がエラーの場合にスローするエラーのメッセージです。
+   */
+  errorMessage?: string;
+  /**
+   * context の名前です。
+   */
+  name?: string;
+}
+
+type CreateContextReturn<T> = [Provider<T>, () => T, Context<T>];
+
+/**
+ * 名前つきの context とそれに対応する Provider を作成する関数です。
+ * TODO: この関数は、conken-oss-pkgs/frontend-react に移動する予定です。
+ *
+ * @param options context のオプションです。
+ */
+export const createContext = <ContextType>(
+  options: CreateContextOptions = {}
+): CreateContextReturn<ContextType> => {
+  const {
+    strict = true,
+    errorMessage = "context は未定義です。コンポーネントをプロバイダ内にラップするのを忘れている可能性があります。",
+    name,
+  } = options;
+
+  const Context = ReactCreateContext<ContextType | undefined>(undefined);
+  Context.displayName = name;
+
+  const useContext = () => {
+    const context = ReactUseContext(Context);
+
+    if (!context && strict) {
+      throw new Error(`${name}: ${errorMessage}`);
+    }
+
+    return context;
+  };
+
+  return [
+    Context.Provider,
+    useContext,
+    Context,
+  ] as CreateContextReturn<ContextType>;
+};


### PR DESCRIPTION
## Issue
なし

## 現状や実装に至った背景
#6 の実装で useContext を使う場面に遭遇した。

## 実装した内容
- createContext という便利関数を実装しました。

## 動作確認
- してません。不具合があったら @kubo-hide-kun に連絡お願いします。
- `frontend-react-emotion` に移行する際はテストコードを書きます。
