### PR TITLE
feat(services): create Todo.Task Entity :sparkles:

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,4 @@
-name: ci
+name: ci-pr
 
 on:
   pull_request:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Test
+        run: npm run test:ci -w @conken-oss-pkgs/services
+
+      - name: Create Coverage Report
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          # pass output from the previous step by id.
+          path: packages/services/coverage/report.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run Test
+      - name: Run test
         run: npm run test:ci
-
-      - name: Create Coverage Report
-        uses: marocchino/sticky-pull-request-comment@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # pass output from the previous step by id.
-          path: packages/services/coverage/report.txt
 
       - name: Check lint
         run: npm run lint
@@ -40,4 +32,3 @@ jobs:
 
       - name: Run typecheck
         run: npm run typecheck
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run Test
+        run: npm run test:ci
+
       # @see https://blog.chick-p.work/blog/github-actions-job-summary
-      - name: Run test:ci
-        run: |
-          npm run test:ci
-          echo '# Coverage Of Services :rocket:' >> $GITHUB_STEP_SUMMARY
-          cat packages/services/coverage/report.txt | sed '1d' | sed '$d' >> $GITHUB_STEP_SUMMARY
+      - uses: artiomtr/jest-coverage-report-action@v1.3
+        id: services-coverage
+        with:
+          test-script: npm run test:ci -w @conken-oss-pkgs/services
+          coverage-file: ./packages/services/coverage/report.json
+          output: report-markdown
+          skip-step: install
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          # pass output from the previous step by id.
+          message: ${{ steps.services-coverage.outputs.report }}
 
       - name: Check lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # @see https://blog.chick-p.work/blog/github-actions-job-summary
       - name: Run test:ci
-        run: npm run test:ci
+        run: |
+          npm run test:ci
+          echo '# Coverage Of Services :rocket:' >> $GITHUB_STEP_SUMMARY
+          cat packages/services/coverage/report.txt | sed '1d' | sed '$d' >> $GITHUB_STEP_SUMMARY
 
       - name: Check lint
         run: npm run lint
@@ -33,7 +37,3 @@ jobs:
       - name: Run typecheck
         run: npm run typecheck
 
-      - uses: actions/setup-node@v2
-        with:
-          name: services-report
-          path: packages/services/package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,20 +24,11 @@ jobs:
       - name: Run Test
         run: npm run test:ci
 
-      # @see https://blog.chick-p.work/blog/github-actions-job-summary
-      - uses: artiomtr/jest-coverage-report-action@v1.3
-        id: services-coverage
-        with:
-          test-script: npm run test:ci -w @conken-oss-pkgs/services
-          coverage-file: ./packages/services/coverage/report.json
-          output: report-markdown
-          skip-step: install
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - name: Create Coverage Report
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
           # pass output from the previous step by id.
-          message: ${{ steps.services-coverage.outputs.report }}
+          path: packages/services/coverage/report.txt
 
       - name: Check lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run test
-        run: npm run test
+      - name: Run test:ci
+        run: npm run test:ci
 
       - name: Check lint
         run: npm run lint
@@ -32,3 +32,8 @@ jobs:
 
       - name: Run typecheck
         run: npm run typecheck
+
+      - uses: actions/setup-node@v2
+        with:
+          name: services-report
+          path: packages/services/package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Create Coverage Report
         uses: marocchino/sticky-pull-request-comment@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # pass output from the previous step by id.
           path: packages/services/coverage/report.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -9743,8 +9743,9 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -31693,17 +31694,18 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.5.1",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -31715,6 +31717,20 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/yargs-parser": {
@@ -51698,6 +51714,8 @@
     },
     "babel-plugin-istanbul": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -66219,18 +66237,31 @@
       "version": "1.10.2"
     },
     "yargs": {
-      "version": "17.5.1",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dev": true,
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
         "yargs-parser": {
           "version": "21.1.1",
           "dev": true

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-storybook": "turbo run build-storybook",
     "fix:all": "run-s lint:fix format:fix typecheck",
     "test": "turbo run test",
+    "test:ci": "turbo run test:ci",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "format": "prettier --check \"**/*.{ts,tsx,md}\"",

--- a/packages/frontend-react-emotion/package.json
+++ b/packages/frontend-react-emotion/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint \"src/**/*.{js,ts,jsx,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{js,ts,jsx,tsx}\" --fix",
     "test": "cypress run --component",
+    "test:ci": "cypress run --component",
     "storybook": "start-storybook -p 9009",
     "typecheck": "tsc --noEmit",
     "build-storybook": "build-storybook",

--- a/packages/services/.gitignore
+++ b/packages/services/.gitignore
@@ -2,6 +2,3 @@ node_modules/
 
 # build
 lib/
-
-# coverage
-report.json

--- a/packages/services/.gitignore
+++ b/packages/services/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 
 # build
 lib/
+
+# coverage
+report.json

--- a/packages/services/jest.config.js
+++ b/packages/services/jest.config.js
@@ -3,14 +3,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   collectCoverage: true,
-  coverageProvider: 'v8',
   collectCoverageFrom: [
     "src/**/*.ts",
-    // export のみのファイルはカバレッジ対象外とする
-    "!src/index.ts",
-    "!src/shared/index.ts",
-    // 型定義のみのファイルはカバレッジ対象外とする
-    "!src/core/**.ts",
     '!**/*.d.ts',
     // 実装のないファイルはカバレッジ対象外とする
     '!**/node_modules/**',

--- a/packages/services/jest.config.js
+++ b/packages/services/jest.config.js
@@ -15,4 +15,14 @@ module.exports = {
     "^~/(.*)$": "<rootDir>/src/$1",
   },
   verbose: true,
+  coverageReporters: [
+    [
+      "text", {
+        "file": "report.txt",
+      }
+    ],
+    [
+      "text"
+    ]
+  ]
 };

--- a/packages/services/jest.config.js
+++ b/packages/services/jest.config.js
@@ -22,6 +22,11 @@ module.exports = {
       }
     ],
     [
+      "json", {
+        "file": "report.json",
+      }
+    ],
+    [
       "text"
     ]
   ]

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint \"src/**/*.{js,ts,jsx,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{js,ts,jsx,tsx}\" --fix",
     "test": "jest --passWithNoTests --coverage",
+    "test:ci": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"report.json\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "npm run build",
     "lint": "eslint \"src/**/*.{js,ts,jsx,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{js,ts,jsx,tsx}\" --fix",
-    "test": "jest --passWithNoTests",
+    "test": "jest --passWithNoTests --coverage",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"src/**/*.{js,ts,jsx,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{js,ts,jsx,tsx}\" --fix",
     "test": "jest --passWithNoTests --coverage",
-    "test:ci": "npm run test -- --coverage --silent --testLocationInResults --ci --json --outputFile=\"report.json\"",
+    "test:ci": "jest --passWithNoTests --coverage",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/src/core/Result/index.spec.ts
+++ b/packages/services/src/core/Result/index.spec.ts
@@ -1,0 +1,27 @@
+import { Core } from "~/core";
+
+describe("SuccessResult", () => {
+  const MOCK_LABEL = "MOCK";
+  const result = Core.Result.success(MOCK_LABEL);
+  it("正誤判定が正常", () => {
+    expect(result.success).toBeTruthy();
+  });
+
+  it("返却された値が正常", () => {
+    const unwrapped = result.unwrap();
+    expect(unwrapped).toBe(MOCK_LABEL);
+  });
+});
+
+describe("FailureResult", () => {
+  const MOCK_ERROR = new Error("failure");
+  const result = Core.Result.failure(MOCK_ERROR);
+
+  it("正誤判定が正常", () => {
+    expect(result.success).toBeFalsy();
+  });
+
+  it("返却された値が正常", () => {
+    expect(() => result.unwrap()).toThrowError(MOCK_ERROR);
+  });
+});

--- a/packages/services/src/core/Result/index.ts
+++ b/packages/services/src/core/Result/index.ts
@@ -69,7 +69,7 @@ class FailureResult<T, E extends Error> extends AbstractResult<T, E> {
   }
 
   protected _getWrapped(
-    _: (data: T) => Result<T, E>,
+    _success: (data: T) => Result<T, E>,
     failure: (error: E) => Result<T, E>
   ): Result<T, E> {
     return failure(this.error);

--- a/packages/services/src/core/Result/index.ts
+++ b/packages/services/src/core/Result/index.ts
@@ -69,7 +69,7 @@ class FailureResult<T, E extends Error> extends AbstractResult<T, E> {
   }
 
   protected _getWrapped(
-    _success: (data: T) => Result<T, E>,
+    _: (data: T) => Result<T, E>,
     failure: (error: E) => Result<T, E>
   ): Result<T, E> {
     return failure(this.error);

--- a/packages/services/src/core/ValueObject.ts
+++ b/packages/services/src/core/ValueObject.ts
@@ -3,13 +3,9 @@ export type Validator<T> = (value: T) => { success: boolean };
 export abstract class ValueObject<T> {
   abstract validator: Validator<T>;
 
-  constructor(protected readonly value: T) {}
+  constructor(readonly value: T) {}
 
-  isValid() {
+  get isValid() {
     return this.validator(this.value);
-  }
-
-  getValue(): T {
-    return this.value;
   }
 }

--- a/packages/services/src/core/ValueObject/index.spec.ts
+++ b/packages/services/src/core/ValueObject/index.spec.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { Core } from "~/core";
+
+describe("ValueObject の検証", () => {
+  const mockSchema = z.string().min(5).max(10);
+
+  type MockValue = z.infer<typeof mockSchema>;
+
+  class MockValueObject extends Core.ValueObject<MockValue> {
+    validator = (value: MockValue) => mockSchema.safeParse(value);
+    constructor(value: string) {
+      super(value);
+    }
+  }
+  it("5以下の文字列を渡すとエラーになる", () => {
+    const mock = new MockValueObject("1234");
+    expect(mock.isValid).toBeFalsy();
+  });
+
+  it("10以上の文字列を渡すとエラーになる", () => {
+    const mock = new MockValueObject("12345678901");
+    expect(mock.isValid).toBeFalsy();
+  });
+
+  it("5以上10以下の文字列を渡すと正常に生成される", () => {
+    const mock = new MockValueObject("12345");
+    expect(mock.isValid).toBeTruthy();
+  });
+});

--- a/packages/services/src/core/ValueObject/index.ts
+++ b/packages/services/src/core/ValueObject/index.ts
@@ -6,6 +6,6 @@ export abstract class ValueObject<T> {
   constructor(readonly value: T) {}
 
   get isValid() {
-    return this.validator(this.value);
+    return this.validator(this.value).success;
   }
 }

--- a/packages/services/src/core/index.ts
+++ b/packages/services/src/core/index.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { Result as CoreResult } from "~/core/Result";
 import { ValueObject as CoreValueObject } from "~/core/ValueObject";
 

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,2 +1,4 @@
+/* istanbul ignore file */
 export { Core } from "~/core";
 export { Shared } from "~/shared";
+export { Todo } from "~/subdomains/todo";

--- a/packages/services/src/shared/index.ts
+++ b/packages/services/src/shared/index.ts
@@ -1,8 +1,5 @@
 /* istanbul ignore file */
-import {
-  Id as SharedId,
-  IdValue as SharedIdValue,
-} from "~/shared/valueObjects/Id";
+import { Id as SharedId } from "~/shared/valueObjects/Id";
 
 export namespace Shared {
   /**
@@ -11,6 +8,5 @@ export namespace Shared {
   export namespace ValueObjects {
     export type Id = SharedId;
     export const Id = SharedId;
-    export type IdValue = SharedIdValue;
   }
 }

--- a/packages/services/src/shared/index.ts
+++ b/packages/services/src/shared/index.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import {
   Id as SharedId,
   IdValue as SharedIdValue,
@@ -8,6 +9,7 @@ export namespace Shared {
    * 値オブジェクトを定義する
    */
   export namespace ValueObjects {
+    export type Id = SharedId;
     export const Id = SharedId;
     export type IdValue = SharedIdValue;
   }

--- a/packages/services/src/shared/valueObjects/Id/index.spec.ts
+++ b/packages/services/src/shared/valueObjects/Id/index.spec.ts
@@ -7,11 +7,17 @@ describe("ID のバリデーションが適切である。", () => {
     { id: "AAAAAAAA-1111-2222-AAAG-111111111111", expected: false },
     { id: "xxxA987FBC9-4BED-3078-CF07-9141BA07C9F3", expected: false },
     { id: "AAAAAAAA-1111-2222-AAAG", expected: false },
+    { id: "ああああああああああ", expected: false },
+    { id: "🙇‍♂️", expected: false },
+    { id: "", expected: false },
   ];
   TEST_CASES.forEach((data) => {
-    it(`${data.expected ? "有効" : "無効"}なID: ${data.id}`, () => {
-      const id = Shared.ValueObjects.Id.create(data.id, `ID: ${data.id}`);
+    it(`${data.expected ? "有効" : "無効"}なID: "${data.id}"`, () => {
+      const id = Shared.ValueObjects.Id.create(data.id, "Test Id");
       expect(id.success).toBe(data.expected);
+      if (data.expected) {
+        expect(id.unwrap().value).toBe(data.id);
+      }
     });
   });
 });

--- a/packages/services/src/shared/valueObjects/Id/index.ts
+++ b/packages/services/src/shared/valueObjects/Id/index.ts
@@ -3,7 +3,7 @@ import { Core } from "~/core";
 
 const idSchema = z.string().uuid();
 
-export type IdValue = z.infer<typeof idSchema>;
+type IdValue = z.infer<typeof idSchema>;
 
 export class Id extends Core.ValueObject<IdValue> {
   /**
@@ -20,6 +20,9 @@ export class Id extends Core.ValueObject<IdValue> {
 }
 
 export namespace Id {
+  export const schema = idSchema;
+  export type Value = IdValue;
+
   /**
    * Id のインスタンスの生成結果を作成する便利関数
    * @param value Id の値
@@ -28,12 +31,11 @@ export namespace Id {
    */
   export const create = (
     value: IdValue,
-    displayName: string
+    displayName = "Shared.ValueObject.Id"
   ): Core.Result<Id> => {
     const id = new Id(value);
 
-    const { success } = id.isValid;
-    if (!success) {
+    if (!id.isValid) {
       return Core.Result.failure(
         new Error(`Invalid ${displayName}, id: ${value}`)
       );

--- a/packages/services/src/shared/valueObjects/Id/index.ts
+++ b/packages/services/src/shared/valueObjects/Id/index.ts
@@ -32,7 +32,7 @@ export namespace Id {
   ): Core.Result<Id> => {
     const id = new Id(value);
 
-    const { success } = id.isValid();
+    const { success } = id.isValid;
     if (!success) {
       return Core.Result.failure(
         new Error(`Invalid ${displayName}, id: ${value}`)

--- a/packages/services/src/subdomains/todo/entities/Task/core.spec.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/core.spec.ts
@@ -1,0 +1,68 @@
+import { Todo } from "~/subdomains/todo";
+
+describe("Todo.Task", () => {
+  const PROPS_MOCK = {
+    id: "E034B584-7D89-11E9-9669-1AECF481A97B",
+    title: "猫です。よろしくお願いします🙇‍♂️",
+    description: "猫です。よろしくお願いします🙇‍♂️",
+    status: "todo",
+    assigneeId: "E034B584-7D89-11E9-9669-1AECF481A97B",
+    createdBy: "E034B584-7D89-11E9-9669-1AECF481A97B",
+  } as const;
+
+  const wrappedTask = Todo.Task.create(PROPS_MOCK);
+
+  it("タスクを作成できる", () => {
+    expect(wrappedTask.success).toBeTruthy();
+  });
+
+  const task = wrappedTask.unwrap();
+
+  it("タスクを作成時の値が正しい", () => {
+    expect(task.id).toBe(PROPS_MOCK.id);
+    expect(task.title).toBe(PROPS_MOCK.title);
+    expect(task.description).toBe(PROPS_MOCK.description);
+    expect(task.status).toBe(PROPS_MOCK.status);
+    expect(task.assigneeId).toBe(PROPS_MOCK.assigneeId);
+    expect(task.createdBy).toBe(PROPS_MOCK.createdBy);
+  });
+
+  const PROPS_MOCK_TO_UPDATE = {
+    title: "犬です。よろしくお願いします🙇‍♂️",
+    status: "doing",
+  } as const;
+
+  const updateResult = task.update(PROPS_MOCK_TO_UPDATE);
+  const updated = updateResult.unwrap();
+
+  it("タスクを更新ができ、その値が適切である", () => {
+    expect(updated.id).toBe(PROPS_MOCK.id);
+    expect(updated.title).toBe(PROPS_MOCK_TO_UPDATE.title);
+    expect(updated.description).toBe(PROPS_MOCK.description);
+    expect(updated.status).toBe(PROPS_MOCK_TO_UPDATE.status);
+    expect(updated.assigneeId).toBe(PROPS_MOCK.assigneeId);
+    expect(updated.createdBy).toBe(PROPS_MOCK.createdBy);
+  });
+
+  const missingUpdated = task.update({
+    title: "",
+  });
+
+  it("不正なタスクの更新はできない", () => {
+    expect(missingUpdated.success).toBeFalsy();
+  });
+});
+
+describe("Todo.Task", () => {
+  const PROPS_MOCK = {
+    id: "E034B584-7D89-11E9-9669",
+    title: "猫です。よろしくお願いします🙇‍♂️",
+    status: "todo",
+    createdBy: "E034B584-7D89-11E9-9669",
+  } as const;
+
+  it("不正な値を受け取った場合にタスクの作成に失敗する", () => {
+    const task = Todo.Task.create(PROPS_MOCK);
+    expect(task.success).toBeFalsy();
+  });
+});

--- a/packages/services/src/subdomains/todo/entities/Task/core.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/core.ts
@@ -1,0 +1,65 @@
+import { Description } from "./valueObject/Description";
+import { Status } from "./valueObject/Status";
+import { Title } from "./valueObject/Title";
+import { Shared } from "~/shared";
+
+export type Field = {
+  id: Shared.ValueObjects.Id;
+  title: Title;
+  description?: Description;
+  assigneeId?: Shared.ValueObjects.Id;
+  createdBy: Shared.ValueObjects.Id;
+  status: Status;
+};
+
+export type Props = Pick<
+  Field,
+  "id" | "title" | "description" | "assigneeId" | "createdBy" | "status"
+>;
+
+export type UpdatableField = Pick<
+  Field,
+  "title" | "description" | "assigneeId" | "status"
+>;
+
+export class Task {
+  readonly id: Props["id"];
+  readonly title: Props["title"];
+  readonly description: Props["description"];
+  readonly assigneeId: Props["assigneeId"];
+  readonly createdBy: Props["createdBy"];
+  readonly status: Props["status"];
+
+  constructor(props: Props) {
+    this.id = props.id;
+    this.title = props.title;
+    this.description = props.description;
+    this.assigneeId = props.assigneeId;
+    this.createdBy = props.createdBy;
+    this.status = props.status;
+  }
+
+  private get currentFields(): Props {
+    return {
+      id: this.id,
+      title: this.title,
+      description: this.description,
+      assigneeId: this.assigneeId,
+      createdBy: this.createdBy,
+      status: this.status,
+    };
+  }
+
+  update(fields: Partial<UpdatableField>): Task {
+    return new Task({
+      ...this.currentFields,
+      ...fields,
+    });
+  }
+}
+
+export namespace Task {
+  export const create = (props: Props): Task => {
+    return new Task(props);
+  };
+}

--- a/packages/services/src/subdomains/todo/entities/Task/index.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/index.ts
@@ -1,11 +1,17 @@
 /* istanbul ignore file */
 import { Task as TaskCore } from "./core";
+import { Description as TaskDescription } from "./valueObject/Description";
 import { Status as TaskStatus } from "./valueObject/Status";
+import { Title as TaskTitle } from "./valueObject/Title";
 
 export type Task = TaskCore;
 
 export namespace Task {
   export const create = TaskCore.create;
+  export type Description = TaskDescription;
+  export const Description = TaskDescription;
   export type Status = TaskStatus;
   export const Status = TaskStatus;
+  export type Title = TaskTitle;
+  export const Title = TaskTitle;
 }

--- a/packages/services/src/subdomains/todo/entities/Task/index.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/index.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+import { Task as TaskCore } from "./core";
+import { Status as TaskStatus } from "./valueObject/Status";
+
+export type Task = TaskCore;
+
+export namespace Task {
+  export const create = TaskCore.create;
+  export type Status = TaskStatus;
+  export const Status = TaskStatus;
+}

--- a/packages/services/src/subdomains/todo/entities/Task/valueObject/Description.spec.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/valueObject/Description.spec.ts
@@ -1,0 +1,22 @@
+import { Todo } from "~/subdomains/todo";
+
+describe("Todo.Task.Description", () => {
+  const TEST_CASES = [
+    { description: "猫です。よろしくお願いします🙇‍♂️", expected: true },
+    { description: "123456789", expected: true },
+    { description: "", expected: true },
+  ];
+
+  TEST_CASES.forEach((data) => {
+    it(`${data.expected ? "有効" : "無効"}な説明文: "${
+      data.description
+    }"`, () => {
+      const description = Todo.Task.Description.create(data.description);
+      expect(description.success).toBe(data.expected);
+      if (data.expected) {
+        const unwrapped = description.unwrap();
+        expect(unwrapped.value).toBe(data.description);
+      }
+    });
+  });
+});

--- a/packages/services/src/subdomains/todo/entities/Task/valueObject/Description.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/valueObject/Description.ts
@@ -3,7 +3,7 @@ import { Core } from "~/core";
 
 const DescriptionSchema = z.string();
 
-export type DescriptionValue = z.infer<typeof DescriptionSchema>;
+type DescriptionValue = z.infer<typeof DescriptionSchema>;
 
 export class Description extends Core.ValueObject<DescriptionValue> {
   validator = (value: DescriptionValue) => {
@@ -16,14 +16,16 @@ export class Description extends Core.ValueObject<DescriptionValue> {
 }
 
 export namespace Description {
+  export const schema = DescriptionSchema;
+  export type Value = DescriptionValue;
+
   export const create = (
     value: DescriptionValue,
-    displayName: string
+    displayName = "ToDo.Task.Description"
   ): Core.Result<Description> => {
     const description = new Description(value);
 
-    const { success } = description.isValid;
-    if (!success) {
+    if (!description.isValid) {
       return Core.Result.failure(
         new Error(`Invalid ${displayName}, Description: ${value}`)
       );

--- a/packages/services/src/subdomains/todo/entities/Task/valueObject/Description.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/valueObject/Description.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { Core } from "~/core";
+
+const DescriptionSchema = z.string();
+
+export type DescriptionValue = z.infer<typeof DescriptionSchema>;
+
+export class Description extends Core.ValueObject<DescriptionValue> {
+  validator = (value: DescriptionValue) => {
+    return DescriptionSchema.safeParse(value);
+  };
+  constructor(value: DescriptionValue) {
+    super(value);
+    Object.freeze(this);
+  }
+}
+
+export namespace Description {
+  export const create = (
+    value: DescriptionValue,
+    displayName: string
+  ): Core.Result<Description> => {
+    const description = new Description(value);
+
+    const { success } = description.isValid;
+    if (!success) {
+      return Core.Result.failure(
+        new Error(`Invalid ${displayName}, Description: ${value}`)
+      );
+    }
+
+    return Core.Result.success(description);
+  };
+}

--- a/packages/services/src/subdomains/todo/entities/Task/valueObject/Status.spec.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/valueObject/Status.spec.ts
@@ -1,0 +1,22 @@
+import { Todo } from "~/subdomains/todo";
+
+describe("Todo.Task.Status", () => {
+  const TEST_CASES = [
+    { status: "todo", expected: true },
+    { status: "doing", expected: true },
+    { status: "done", expected: true },
+  ] as const;
+
+  TEST_CASES.forEach((data) => {
+    it(`${data.expected ? "有効" : "無効"}なステータス: "${
+      data.status
+    }"`, () => {
+      const status = Todo.Task.Status.create(data.status);
+      expect(status.success).toBe(data.expected);
+      if (data.expected) {
+        const unwrapped = status.unwrap();
+        expect(unwrapped.value).toBe(data.status);
+      }
+    });
+  });
+});

--- a/packages/services/src/subdomains/todo/entities/Task/valueObject/Status.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/valueObject/Status.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { Core } from "~/core";
+
+const StatusSchema = z.enum(["todo", "doing", "done"]);
+
+export type StatusValue = z.infer<typeof StatusSchema>;
+
+export class Status extends Core.ValueObject<StatusValue> {
+  validator = (value: StatusValue) => {
+    return StatusSchema.safeParse(value);
+  };
+  constructor(value: StatusValue) {
+    super(value);
+    Object.freeze(this);
+  }
+}
+
+export namespace Status {
+  export const create = (
+    value: StatusValue,
+    displayName: string
+  ): Core.Result<Status> => {
+    const status = new Status(value);
+
+    const { success } = status.isValid;
+    if (!success) {
+      return Core.Result.failure(
+        new Error(`Invalid ${displayName}, status: ${value}`)
+      );
+    }
+
+    return Core.Result.success(status);
+  };
+}

--- a/packages/services/src/subdomains/todo/entities/Task/valueObject/Status.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/valueObject/Status.ts
@@ -3,7 +3,7 @@ import { Core } from "~/core";
 
 const StatusSchema = z.enum(["todo", "doing", "done"]);
 
-export type StatusValue = z.infer<typeof StatusSchema>;
+type StatusValue = z.infer<typeof StatusSchema>;
 
 export class Status extends Core.ValueObject<StatusValue> {
   validator = (value: StatusValue) => {
@@ -16,14 +16,16 @@ export class Status extends Core.ValueObject<StatusValue> {
 }
 
 export namespace Status {
+  export const schema = StatusSchema;
+  export type Value = StatusValue;
+
   export const create = (
     value: StatusValue,
-    displayName: string
+    displayName = "ToDo.Task.Status"
   ): Core.Result<Status> => {
     const status = new Status(value);
 
-    const { success } = status.isValid;
-    if (!success) {
+    if (!status.isValid) {
       return Core.Result.failure(
         new Error(`Invalid ${displayName}, status: ${value}`)
       );

--- a/packages/services/src/subdomains/todo/entities/Task/valueObject/Title.spec.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/valueObject/Title.spec.ts
@@ -1,0 +1,22 @@
+import { Todo } from "~/subdomains/todo";
+
+describe("Todo.Task.Title", () => {
+  const TEST_CASES = [
+    { description: "猫です。よろしくお願いします🙇‍♂️", expected: true },
+    { description: "123456789", expected: true },
+    { description: "", expected: false },
+  ];
+
+  TEST_CASES.forEach((data) => {
+    it(`${data.expected ? "有効" : "無効"}なタイトル: "${
+      data.description
+    }"`, () => {
+      const title = Todo.Task.Title.create(data.description);
+      expect(title.success).toBe(data.expected);
+      if (data.expected) {
+        const unwrapped = title.unwrap();
+        expect(unwrapped.value).toBe(data.description);
+      }
+    });
+  });
+});

--- a/packages/services/src/subdomains/todo/entities/Task/valueObject/Title.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/valueObject/Title.ts
@@ -3,7 +3,7 @@ import { Core } from "~/core";
 
 const TitleSchema = z.string().min(1);
 
-export type TitleValue = z.infer<typeof TitleSchema>;
+type TitleValue = z.infer<typeof TitleSchema>;
 
 export class Title extends Core.ValueObject<TitleValue> {
   validator = (value: TitleValue) => {
@@ -16,14 +16,16 @@ export class Title extends Core.ValueObject<TitleValue> {
 }
 
 export namespace Title {
+  export const schema = TitleSchema;
+  export type Value = TitleValue;
+
   export const create = (
     value: TitleValue,
-    displayName: string
+    displayName = "ToDo.Task.Title"
   ): Core.Result<Title> => {
     const title = new Title(value);
 
-    const { success } = title.isValid;
-    if (!success) {
+    if (!title.isValid) {
       return Core.Result.failure(
         new Error(`Invalid ${displayName}, status: ${value}`)
       );

--- a/packages/services/src/subdomains/todo/entities/Task/valueObject/Title.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/valueObject/Title.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { Core } from "~/core";
+
+const TitleSchema = z.string().min(1);
+
+export type TitleValue = z.infer<typeof TitleSchema>;
+
+export class Title extends Core.ValueObject<TitleValue> {
+  validator = (value: TitleValue) => {
+    return TitleSchema.safeParse(value);
+  };
+  constructor(value: TitleValue) {
+    super(value);
+    Object.freeze(this);
+  }
+}
+
+export namespace Title {
+  export const create = (
+    value: TitleValue,
+    displayName: string
+  ): Core.Result<Title> => {
+    const title = new Title(value);
+
+    const { success } = title.isValid;
+    if (!success) {
+      return Core.Result.failure(
+        new Error(`Invalid ${displayName}, status: ${value}`)
+      );
+    }
+
+    return Core.Result.success(title);
+  };
+}

--- a/packages/services/src/subdomains/todo/index.ts
+++ b/packages/services/src/subdomains/todo/index.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+import { Task as TaskEntity } from "./entities/Task";
+
+export namespace Todo {
+  export type Task = TaskEntity;
+  export const Task = TaskEntity;
+}

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,9 @@
     "test": {
       "outputs": []
     },
+    "test:ci": {
+      "outputs": []
+    },
     "lint": {
       "outputs": []
     },


### PR DESCRIPTION
- `Todo` リストサービスの開発を行いました → `Task` の `Entity` のみ
- `Jest Coverage` の PR に自動通知されるように修正。