### PR TITLE
feat(services): add support to create Todo.Task without going through result :sparkles:

### DIFF
--- a/packages/services/src/subdomains/todo/entities/Task/core.spec.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/core.spec.ts
@@ -44,12 +44,62 @@ describe("Todo.Task", () => {
     expect(updated.createdBy).toBe(PROPS_MOCK.createdBy);
   });
 
+  const PROPS_MOCK_TO_UPDATE_BY_METHOD_CHAINING = [
+    {
+      title: "人です。よろしくお願いします🙇‍♂️",
+      status: "done",
+    },
+    {
+      title: "人でした。よろしくお願いします🙇‍♂️",
+      description: "人でした。よろしくお願いします🙇‍♂️",
+    },
+  ] as const;
+
+  const updatedByMethodChainingResult = task
+    .update(PROPS_MOCK_TO_UPDATE_BY_METHOD_CHAINING[0], { unwrap: true })
+    .update(PROPS_MOCK_TO_UPDATE_BY_METHOD_CHAINING[1]);
+
+  const updatedByMethodChaining = updatedByMethodChainingResult.unwrap();
+
+  it("メソッドチェインを使って、タスクの更新ができ、その値が適切である", () => {
+    expect(updatedByMethodChaining.title).toBe(
+      PROPS_MOCK_TO_UPDATE_BY_METHOD_CHAINING[1].title
+    );
+    expect(updatedByMethodChaining.description).toBe(
+      PROPS_MOCK_TO_UPDATE_BY_METHOD_CHAINING[1].description
+    );
+    expect(updatedByMethodChaining.status).toBe(
+      PROPS_MOCK_TO_UPDATE_BY_METHOD_CHAINING[0].status
+    );
+  });
+
   const missingUpdated = task.update({
     title: "",
   });
 
   it("不正なタスクの更新はできない", () => {
     expect(missingUpdated.success).toBeFalsy();
+  });
+
+  it("{ unwrap: true } の場合、不正な値を受け取った瞬間に例外を投げる", () => {
+    expect(() => {
+      task.update(
+        {
+          title: "",
+        },
+        { unwrap: true }
+      );
+    }).toThrowError();
+  });
+
+  it("forceCreate を使うと、 Result を経由せずに Task インスタンスを生成できる", () => {
+    const forceCreated = Todo.Task.forceCreate(PROPS_MOCK);
+    expect(forceCreated.id).toBe(PROPS_MOCK.id);
+    expect(forceCreated.title).toBe(PROPS_MOCK.title);
+    expect(forceCreated.description).toBe(PROPS_MOCK.description);
+    expect(forceCreated.status).toBe(PROPS_MOCK.status);
+    expect(forceCreated.assigneeId).toBe(PROPS_MOCK.assigneeId);
+    expect(forceCreated.createdBy).toBe(PROPS_MOCK.createdBy);
   });
 });
 
@@ -64,5 +114,11 @@ describe("Todo.Task", () => {
   it("不正な値を受け取った場合にタスクの作成に失敗する", () => {
     const task = Todo.Task.create(PROPS_MOCK);
     expect(task.success).toBeFalsy();
+  });
+
+  it("forceCreate を使うと、不正な値を受け取った瞬間に例外を投げる", () => {
+    expect(() => {
+      Todo.Task.forceCreate(PROPS_MOCK);
+    }).toThrowError();
   });
 });

--- a/packages/services/src/subdomains/todo/entities/Task/core.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/core.ts
@@ -58,11 +58,23 @@ export class Task {
     };
   }
 
-  update(fields: Partial<UpdatableField>): Core.Result<Task> {
+  update(fields: Partial<UpdatableField>): Core.Result<Task>;
+  update(fields: Partial<UpdatableField>, { unwrap }: { unwrap: true }): Task;
+  update(
+    fields: Partial<UpdatableField>,
+    { unwrap }: { unwrap: boolean } = { unwrap: false }
+  ): Task | Core.Result<Task> {
     const updated = new Task({
       ...this.currentFields,
       ...fields,
     });
+
+    if (unwrap) {
+      if (!updated.isValid) {
+        throw new Error(`Invalid Task, props: ${JSON.stringify(fields)}`);
+      }
+      return updated;
+    }
 
     if (!updated.isValid) {
       return Core.Result.failure(
@@ -88,5 +100,20 @@ export namespace Task {
     }
 
     return Core.Result.success(task);
+  };
+
+  export const forceCreate = (
+    props: Props,
+    displayName = "Todo.Task"
+  ): Task => {
+    const task = new Task(props);
+
+    if (!task.isValid) {
+      throw new Error(
+        `Invalid ${displayName}, props: ${JSON.stringify(props)}`
+      );
+    }
+
+    return task;
   };
 }

--- a/packages/services/src/subdomains/todo/entities/Task/index.ts
+++ b/packages/services/src/subdomains/todo/entities/Task/index.ts
@@ -8,6 +8,7 @@ export type Task = TaskCore;
 
 export namespace Task {
   export const create = TaskCore.create;
+  export const forceCreate = TaskCore.forceCreate;
   export type Description = TaskDescription;
   export const Description = TaskDescription;
   export type Status = TaskStatus;


### PR DESCRIPTION
## 概要
インスタンス生成時に必ず `result` を経由する必要があるとメソッドチェインによる更新処理をかけないので、
`result` を経由しないインスタンスの生成を行えるようにしました。

```ts
const updatedByMethodChainingResult = task
  .update(PROPS_MOCK_TO_UPDATE_BY_METHOD_CHAINING[0], { unwrap: true })
  .update(PROPS_MOCK_TO_UPDATE_BY_METHOD_CHAINING[1]);

const updatedByMethodChaining = updatedByMethodChainingResult.unwrap();
```